### PR TITLE
Simplify IdleManager Threading and WithoutConnection usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ test/dummy/db/*.sqlite3-journal
 test/dummy/log/*.log
 test/dummy/tmp/
 test/dummy/.sass-cache
+apartment

--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ bundle exec rails generate advanced_connection:install
 #### Idle Connection Manager
 
 Enabling this will enable idle connection management. This allows you to specify settings
-to enable automatic warmup of connections on rails startup, min/max idle connections and
-idle connection culling.
+to enable automatic idle connection reaping.
 
 ```text
   enable_idle_connection_manager = true | false
@@ -59,16 +58,6 @@ Pool queue type determines both how free connections will be checkout out of the
 
 ```text
   connection_pool_queue_type = :fifo | :lifo | :stack | :prefer_older | :prefer_younger
-```
-
-How many connections to prestart on initial startup of rails. This can help to reduce the time it takes a restarted production node to start responding again.
-```text
-  warmup_connections = integer | false
-```
-
-Minimum number of connection to keep idle. If, during the idle check, you have fewer than this many connections idle, then a number of new connections will be created up to this this number.
-```text
-  min_idle_connections = integer
 ```
 
 Maximum number of connections that can remain idle without being culled. If you have

--- a/lib/advanced_connection/active_record_ext.rb
+++ b/lib/advanced_connection/active_record_ext.rb
@@ -38,21 +38,12 @@ module AdvancedConnection
       end
 
       ActiveRecord::ConnectionAdapters::ConnectionPool.instance_exec do
-        if AdvancedConnection.enable_idle_connection_manager
-          include ConnectionPool::IdleManager
-        end
-
-        if AdvancedConnection.enable_statement_pooling
-          include ConnectionPool::StatementPooling
-        elsif AdvancedConnection.enable_without_connection
-          include ConnectionPool::WithoutConnection
-        end
+        include ConnectionPool::IdleManager if AdvancedConnection.enable_idle_connection_manager
+        include ConnectionPool::WithoutConnection
       end
 
       ActiveRecord::Base.instance_exec do
-        if AdvancedConnection.enable_without_connection
-          extend ActiveRecordExt::WithoutConnection unless AdvancedConnection.enable_statement_pooling
-        end
+        extend ActiveRecordExt::WithoutConnection
       end
     end
   end

--- a/lib/advanced_connection/active_record_ext/connection_pool/queues.rb
+++ b/lib/advanced_connection/active_record_ext/connection_pool/queues.rb
@@ -38,6 +38,7 @@ module AdvancedConnection::ActiveRecordExt
       class AgeSorted < Default
         def poll(timeout = nil)
           synchronize do
+            # always sort age based queues from youngest to oldest
             @queue.sort_by!(&:instance_age)
             no_wait_poll || (timeout && wait_poll(timeout))
           end
@@ -46,12 +47,16 @@ module AdvancedConnection::ActiveRecordExt
 
       class YoungAgeBiased < AgeSorted
         def remove
+          # Think of this like a stack, sorted youngest to oldest, bottom to top. To to
+          # aquire the youngest entry, we shift it off the bottom (i.e., the first element)
           @queue.shift
         end
       end
 
       class OldAgeBiased < AgeSorted
         def remove
+          # Think of this like a stack, sorted youngest to oldest, bottom to top. To to
+          # aquire the oldest entry, we pop it off the top (i.e., the last element)
           @queue.pop
         end
       end

--- a/lib/advanced_connection/error.rb
+++ b/lib/advanced_connection/error.rb
@@ -23,5 +23,6 @@ module AdvancedConnection
   class Error < StandardError
     class ConfigError < Error; end
     class UnableToReleaseConnection < Error; end
+    class UnableToReaquireConnection < Error; end
   end
 end

--- a/lib/advanced_connection/railtie.rb
+++ b/lib/advanced_connection/railtie.rb
@@ -41,12 +41,6 @@ module AdvancedConnection
           ActiveRecord::Base.send(:include, AdvancedConnection::ActiveRecordExt)
         }
       end
-
-      config.after_initialize do
-        if AdvancedConnection.enable_idle_connection_manager && AdvancedConnection.warmup_connections
-          ActiveRecord::Base.connection_handler.connection_pool_list.each(&:warmup_connections)
-        end
-      end
     end
   end
 end

--- a/lib/generators/advanced_connection/install/templates/advanced_connection.rb
+++ b/lib/generators/advanced_connection/install/templates/advanced_connection.rb
@@ -6,42 +6,33 @@ AdvancedConnection.configure do |config|
   ## Idle Manager
   #
   # Enabling this will enable idle connection management. This allows you to specify settings
-  # to enable automatic warmup of connections on rails startup, min/max idle connections and
-  # idle connection culling.
+  # to enable the automatic reaping of idle database connections.
+  #
   # config.enable_idle_connection_manager = <%= AdvancedConnection::Config::DEFAULT_CONFIG.enable_idle_connection_manager.inspect %>
 
   # Pool queue type determines both how free connections will be checkout out
-  # of the pool, as well as how idle connections will be culled. The options are:
+  # of the pool, as well as how idle connections will be reaped. The options are:
   #
-  #  :fifo           - All connections will have an equal opportunity to be used and culled (default)
+  #  :fifo           - All connections will have an equal opportunity to be used and reaped (default)
   #  :lifo/:stack    - More frequently used connections will be reused, leaving less frequently used
-  #                    connections to be culled
+  #                    connections to be reaped
   #  :prefer_older   - Longer lived connections will tend to stick around longer, with younger
-  #                    connections being culled
+  #                    connections being reaped
   #  :prefer_younger - Younger lived connections will tend to stick around longer, with older
-  #                    connections being culled
+  #                    connections being reaped
   #
   # config.connection_pool_queue_type     = <%= AdvancedConnection::Config::DEFAULT_CONFIG.connection_pool_queue_type.inspect %>
 
-  # How many connections to prestart on initial startup of rails. This can
-  # help to reduce the time it takes a restarted production node to start
-  # responding again.
-  #
-  # config.warmup_connections             = <%= AdvancedConnection::Config::DEFAULT_CONFIG.warmup_connections.inspect %>
+  # What log level to log idle manager stats and details at (see ::Logger#level)
+  # config.idle_manager_log_level = ::Logger::INFO
 
-  # Minimum number of connection to keep idle. If, during the idle check, you have fewer
-  # than this many connections idle, then a number of new connections will be created
-  # up to this this number.
-  #
-  # config.min_idle_connections           = <%= AdvancedConnection::Config::DEFAULT_CONFIG.min_idle_connections.inspect %>
-
-  # Maximum number of connections that can remain idle without being culled. If you have
+  # Maximum number of connections that can remain idle without being reaped. If you have
   # more idle conections than this, only the difference between the total idle and this
-  # maximum will be culled.
+  # maximum will be reaped.
   #
   # config.max_idle_connections           = ::Float::INFINITY
 
-  # How long (in seconds) a connection can remain idle before being culled
+  # How long (in seconds) a connection can remain idle before being reaped
   #
   # config.max_idle_time                  = 90
 


### PR DESCRIPTION
- remove synchronization around non-critical blocks (read-only)
- fully synchronize reaping code
- ensure without_connection doesn't drop connection if open transaction present
- ensure without_connection is callable without being enabled (just yields and returns)
- added comments to more explicitly describe queues
- removed warmup_connections and min_idle_connections - letting rails add new conns on it's own now
  - cleaned up code due to removal of warmup/min_idle options
